### PR TITLE
Ansible inventory SSH options for better testinfra support

### DIFF
--- a/molecule/core.py
+++ b/molecule/core.py
@@ -215,7 +215,7 @@ class Molecule(object):
         inventory = ''
         # TODO: for Ansiblev2, the following line must have s/ssh_//
         host_template = \
-            '{} ansible_ssh_host={} ansible_ssh_port={} ansible_ssh_private_key_file={} ansible_ssh_user={}\n'
+            '{} ansible_ssh_host={} ansible_ssh_port={} ansible_ssh_private_key_file={} ansible_ssh_user={} ansible_ssh_extra_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"\n'
         for instance in self._provisioner.instances:
             ssh = self._provisioner.conf(
                 vm_name=utilities.format_instance_name(


### PR DESCRIPTION
Testinfra doesn't inherit all of the SSH options that Molecule uses during the converge phase which was causing testinfra to not be able to run because it couldn't SSH to the VM. It was prompting to accept the SSH fingerprint and would just hang. Adding SSH's StrictHostKeyChecking=no and UserKnownHostsFile=/dev/null to the ansible_inventory file allows testinfra to properly SSH to the VM and perform the tests.

Before the change:
```
Executing testinfra tests found in tests/.
============================= test session starts ==============================
platform darwin -- Python 2.7.11, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /Users/me/code/ansible/roles/foo, inifile: pytest.ini
plugins: testinfra-1.2.0
collected 4 items

tests/test_foo.py The authenticity of host '[127.0.0.1]:2200 ([127.0.0.1]:2200)' can't be established.
ECDSA key fingerprint is SHA256:uBXjhivauuYiPdv47uwCBxZNElAKY3MaPn5UCF7BEuw.
```
And at this point the command would hang forever.

After the change:
```
Executing testinfra tests found in tests/.
============================= test session starts ==============================
platform darwin -- Python 2.7.11, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /Users/me/code/ansible/roles/foo, inifile: pytest.ini
plugins: testinfra-1.2.0
collected 4 items

tests/test_foo.py ....

=========================== 4 passed in 3.08 seconds ===========================
```